### PR TITLE
A payer can pay for himself

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,13 +89,8 @@ fn add_expense(all_users: &mut Vec<User>, all_transactions: &mut Transactions) {
 
     match selected_user {
         Ok(selected_user) => {
-            let giver_list: Vec<&str> = payer_list
-                .into_iter()
-                .filter(|&name| name != selected_user)
-                .collect();
-
             let giver_names: Result<Vec<&str>, InquireError> =
-                MultiSelect::new("Please select the givers of expense:", giver_list.clone())
+                MultiSelect::new("Please select the givers of expense:", payer_list.clone())
                     .prompt();
 
             match giver_names {

--- a/src/split.rs
+++ b/src/split.rs
@@ -46,11 +46,11 @@ impl Transactions {
     }
 
     pub fn display(&self) {
-        println!("{0: <10} | {1: <10} | {2: <10}", "From", "To", "Amount");
+        println!("{0: <10} | {1: <10} | {2: <10}", "Who", "Owes To", "Amount");
         for i in &self.transactions {
             println!(
                 "{0: <10} | {1: <10} | {2: <10}",
-                i.from.name, i.to.name, i.amount
+                i.to.name, i.from.name, i.amount
             );
         }
     }


### PR DESCRIPTION
Hello,

First, thanks a lot for creating this tool. It’s efficient and slick.
However, one limitation prevents me from using that tool: I would like a payer to be on the list of givers.
For example, a group of friends go to the movies, and one person pays for everyone, including his own ticket. In that case, I would like to specify that the payer is also one of the givers.

Here is a small modification of your code to allow that. Everything seems to work correctly, but please ensure I don’t break something.

I also modified the bill-splitting table to show who owes what to whom more clearly.

Best